### PR TITLE
Feast of Souls should only remove the soul stacks at the end of the modifier, not on cast.

### DIFF
--- a/game/dota_addons/ebf/resource/addon_english.txt
+++ b/game/dota_addons/ebf/resource/addon_english.txt
@@ -2053,6 +2053,9 @@
 		"DOTA_Tooltip_modifier_nevermore_dark_lord_passive_aura_Description"                                "Armor changed by %dMODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS%."
 		
 		"DOTA_Tooltip_ability_nevermore_requiem_damage"														"DAMAGE PER LINE:"
+
+		"DOTA_Tooltip_modifier_nevermore_frenzy_ebf"										"Feast of Souls"
+		"DOTA_Tooltip_modifier_nevermore_frenzy_ebf_Description"							"Attack speed increased by %dMODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT%. Cast speed increased by %dMODIFIER_PROPERTY_CASTTIME_PERCENTAGE%%%."
 		
 		//Night Stalker
 		"DOTA_Tooltip_ability_night_stalker_crippling_fear_Description"                                     "Night Stalker horrifies all nearby enemies, causing them to become silenced and miss a percentage of their attacks while near him.\n\nAt night, the effect lasts longer and he passively causes enemies within the ability's radius to miss attacks. This miss chance stacks with the active miss chance.<br>COOLDOWN TYPE: When Buff Expires"

--- a/game/dota_addons/ebf/scripts/vscripts/heroes/hero_shadow_fiend/nevermore_frenzy.lua
+++ b/game/dota_addons/ebf/scripts/vscripts/heroes/hero_shadow_fiend/nevermore_frenzy.lua
@@ -15,11 +15,44 @@ end
 
 function nevermore_frenzy:OnSpellStart()
 	local caster = self:GetCaster()
-	
 	EmitSoundOn( "Hero_Nevermore.Frenzy", caster )
-	local souls = caster:FindModifierByName("modifier_nevermore_necromastery_passive")
+	caster:AddNewModifier( caster, self, "modifier_nevermore_frenzy_ebf", {duration = self:GetSpecialValueFor("duration")} )
+end
+
+modifier_nevermore_frenzy_ebf = class({})
+LinkLuaModifier( "modifier_nevermore_frenzy_ebf","heroes/hero_shadow_fiend/nevermore_frenzy.lua", LUA_MODIFIER_MOTION_NONE )
+
+function modifier_nevermore_frenzy_ebf:OnCreated()
+	self:OnRefresh()
+end
+
+function modifier_nevermore_frenzy_ebf:OnRefresh()
+	self.attack_speed = self:GetSpecialValueFor("bonus_attack_speed")
+	self.cast_speed = self:GetSpecialValueFor("cast_speed_pct")
+	self.soul_cost = self:GetSpecialValueFor("soul_cost")
+end
+
+function modifier_nevermore_frenzy_ebf:OnRemoved()
+	if IsClient() then return end
+	local parent = self:GetParent()
+	local souls = parent:FindModifierByName("modifier_nevermore_necromastery_passive")
 	if souls then
-		souls:SetStackCount( math.max( 0, souls:GetStackCount() - self:GetSpecialValueFor("soul_cost") ) )
+		souls:SetStackCount( math.max( 0, souls:GetStackCount() - self.soul_cost ) )
 	end
-	caster:AddNewModifier( caster, self, "modifier_nevermore_frenzy", {duration = self:GetSpecialValueFor("duration")} )
+end
+
+function modifier_nevermore_frenzy_ebf:DeclareFunctions()
+	return {MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT, MODIFIER_PROPERTY_CASTTIME_PERCENTAGE}
+end
+
+function modifier_nevermore_frenzy_ebf:GetModifierPercentageCasttime()
+	return self.cast_speed - 100
+end
+
+function modifier_nevermore_frenzy_ebf:GetModifierAttackSpeedBonus_Constant()
+	return self.attack_speed
+end
+
+function modifier_nevermore_frenzy_ebf:GetEffectName()
+	return "particles/items2_fx/mask_of_madness.vpcf"
 end


### PR DESCRIPTION
Tested locally, parity with vanilla behavior.