### PR TITLE
Axe tweaks before new facets

### DIFF
--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_axe.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_axe.txt
@@ -50,13 +50,13 @@
 				"special_bonus_facet_axe_call_out"	"+5"
 				"special_bonus_unique_axe_7"		"+12"
 			}
-			"duration"								"3.0"
+			"duration"								"4.0"
 			"AbilityCooldown"
 			{
-				"value"								"11"
-				"special_bonus_scepter" 			"-3.0"
+				"value"								"12"
+				"special_bonus_scepter" 			"-4.0"
 			}
-			"AbilityManaCost"						"35"
+			"AbilityManaCost"						"20"
 			"applies_battle_hunger"
 			{
 				"special_bonus_shard"				"+1"
@@ -117,8 +117,8 @@
 		"AbilityValues"
 		{
 			"AbilityCooldown"						"1"
-			"AbilityManaCost"						"25"
-			"duration"								"12.0"
+			"AbilityManaCost"						"5"
+			"duration"								"16.0"
 			"slow"
 			{
 				"value"								"-11 -19 -27 -35 -43 -51 -59"
@@ -126,7 +126,7 @@
 			}
 			"damage_per_second"	
 			{
-				"value"								"100 150 200 250 300 350 400"
+				"value"								"150 200 250 300 350 400 450"
 				"CalculateSpellDamageTooltip"		"1"
 			}
 			"armor_multiplier"			
@@ -207,7 +207,7 @@
 			}
 			"attacks_increase_counter"
 			{
-				"special_bonus_scepter"			"1"
+				"special_bonus_scepter"			"3"
 			}
 		}
 		"AbilityCastAnimation"		"ACT_DOTA_CAST_ABILITY_3"
@@ -249,7 +249,7 @@
 
 		// Cost
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityManaCost"				"80"
+		"AbilityManaCost"				"55"
 		
 		// Cast Range
 		//-------------------------------------------------------------------------------------------------------------
@@ -284,7 +284,7 @@
 				"special_bonus_unique_axe_3"	"+1"
 			}
 			"hero_cd_reduction"					"50"
-			"grace_period"						"3.0"
+			"grace_period"						"4.0"
 		}
 	}
 }


### PR DESCRIPTION
Changes to Taunt mana cost and overall duration to make it frontline-oriented.
Changes to Battle hunger mana cost/duration/damage to make it last longer, and give axe more survivability from it's damage.
Changes to counterhelix attack counter to proc more often on solo unit.
Changes to Ultimate manacost and grace period to grant bonus movespeed and stack.