### PR TITLE
Update hero_juggernaut.txt

### DIFF
--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_juggernaut.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_juggernaut.txt
@@ -95,24 +95,23 @@
 		{
 			"AbilityCooldown"
 			{
-				"value"					"42 34 26 18"
+				"value"					"30 25 20 15"
 				"special_bonus_unique_juggernaut_blade_fury_cooldown"		"-3"
 			}
 			"blade_fury_aspd_multiplier"
 			{
-				"value"		"2.0"
+				"value"		"1.75"
 			}
 			"blade_fury_radius"			
 			{
 				"value"						"260"
 				"special_bonus_unique_juggernaut"		"+100"
-				"special_bonus_shard"		"+100"
 				"affected_by_aoe_increase"	"1"
 			}
 			"blade_fury_damage_per_tick"			
 			{
-				"value"									"400 450 500 550"
-				"special_bonus_unique_juggernaut_3"		"+50%"
+				"value"									"250 300 350 400"
+				"special_bonus_unique_juggernaut_3"		"+35%"
 				"CalculateSpellDamageTooltip"			"1"
 			}
 			"duration"					


### PR DESCRIPTION
Blade Fury is incredibly powerful. Tuned down some numbers to bring it more in line with other heroes.

The primary issue is that, even on nightmare, Blade Fury trivializes the early game by dealing 3-4x as much damage as it arguably should, being able to kill many boss enemies in the first few rounds in a single cast, and remains an incredible damage source for the rest of the game (provided you itemize well).

Changes:

- Damage per tick reduced from 400/450/500/550 to 250/300/350/400.
- Level 10 damage talent reduced from +50% to +35%.
- Attack speed multiplier reduced from 2.0 to 1.75.
- Removed the 100 radius given by the (now free) Shard.
- As recompense, decreased the cooldown from 42/34/26/18 to 30/25/20/15.