### PR TITLE
Invo, LoneDruid, Pango, Razor, Snap, Tusk, Weaver

### DIFF
--- a/game/dota_addons/ebf/resource/addon_english.txt
+++ b/game/dota_addons/ebf/resource/addon_english.txt
@@ -3694,6 +3694,7 @@
 		//Weaver
 		"DOTA_Tooltip_ability_weaver_geminate_attack_shard_description"										"Geminate Attack's cooldown is reduced."
 		"DOTA_Tooltip_ability_weaver_geminate_attack_AbilityCooldown"										"COOLDOWN:"
+		"DOTA_Tooltip_ability_weaver_geminate_attack_extra_attack"											"EXTRA ATTACK:"
 		
 		//Wisp
 		"DOTA_Tooltip_ability_wisp_sacrifice"                                                               "Sacrifice"

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_invoker.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_invoker.txt
@@ -63,7 +63,7 @@
 			}
 			"strength_bonus"
 			{
-				"value"										"1"
+				"value"										"10"
 				"CalculateAttributeTooltip"					"1"
 			}
 			
@@ -120,7 +120,7 @@
 			}		
 			"agility_bonus"
 			{
-				"value"										"1"
+				"value"										"10"
 				"CalculateAttributeTooltip"					"1"
 			}
 
@@ -171,8 +171,9 @@
 			}
 			"bonus_damage_per_instance"
 			{
-				"value"								"1 3 5 7 9 11 13 15 17 19"
+				"value"								"10 30 50 70 90 110 130 150 170 190"
 				"special_bonus_unique_invoker_13"	"x2"
+				"CalculateAttributeTooltip"			"1"
 			}
 			"upgrade_at_level"
 			{
@@ -181,7 +182,7 @@
 			}	
 			"intelligence_bonus"
 			{
-				"value"										"1"
+				"value"										"10"
 				"CalculateAttributeTooltip"					"1"
 			}
 
@@ -309,23 +310,23 @@
 		{
 			"AbilityCooldown"
 			{
-				"value"					"18"
+				"value"					"13"
 				"special_bonus_unique_invoker_9"	"-5"
 			}
 			"duration"
 			{
-				"value"					"3.0 3.4 3.8 4.2 4.6 5.0 5.4 5.8 6.2 6.6"
+				"value"					"3.0 3.4 3.8 4.2 4.6 5.0 5.4 5.8 7.0 8.2"
 				"levelkey"				"quaslevel"	
 			}
 			"freeze_duration"			"0.4"
 			"freeze_cooldown"
 			{
-				"value"					"0.80 0.77 0.74 0.71 0.68 0.65 0.62 0.59 0.56 0.53"
+				"value"					"0.80 0.77 0.74 0.71 0.68 0.65 0.62 0.59 0.50 0.41"
 				"levelkey"				"quaslevel"	
 			}
 			"freeze_damage"
 			{
-				"value"					"80 160 240 320 400 480 560 640 680 720"
+				"value"					"80 160 240 320 400 480 560 640 920 1160"
 				"CalculateSpellDamageTooltip"	"1"
 				"levelkey"				"quaslevel"	
 			}
@@ -366,7 +367,7 @@
 		{
 			"AbilityCooldown"
 			{
-				"value"					"32"
+				"value"					"25"
 			}
 			"duration"				"60"
 			"area_of_effect"		
@@ -376,24 +377,24 @@
 			}
 			"enemy_slow"
 			{
-				"value"					"-20 -25 -30 -35 -40 -45 -50 -55 -60 -65"
+				"value"					"-20 -25 -30 -35 -40 -45 -50 -55 -70 -85"
 				"levelkey"				"quaslevel"
 			}
 			"self_slow"
 			{
-				"value"					"-20 -15 -10 -5 0 5 10 15 20 25"
+				"value"					"-20 -15 -10 -5 0 5 10 15 30 45"
 				"levelkey"				"wexlevel"
 			}		
 			"aura_fade_time"			"2.0"
 			"health_regen"				
 			{
-				"value"					"20 40 60 80 100 120 140 160 180 200"
+				"value"					"20 40 60 80 100 120 140 160 220 280"
 				"CalculateSpellHealTooltip"	"1"
 				"levelkey"				"quaslevel"
 			}
 			"mana_regen"			
 			{
-				"value"					"2 4 6 8 10 12 14 16 18 20"
+				"value"					"2 4 6 8 10 12 14 16 22 28"
 				"levelkey"				"wexlevel"
 			}
 			"ally_cast_area_of_effect"
@@ -443,12 +444,12 @@
 		{
 			"AbilityCooldown"
 			{
-				"value"					"27"
+				"value"					"20"
 				"special_bonus_unique_invoker_3" "-4"
 			}
 			"travel_distance"
 			{
-				"value"					"1500 1800 2100 2400 2700 3000 3300 3600 3900 4200"
+				"value"					"1500 1800 2100 2400 2700 3000 3300 3600 4500 5100"
 				"levelkey"				"wexlevel"
 			}
 			"travel_speed"			"1000"
@@ -465,7 +466,7 @@
 			"end_vision_duration"	"1.75"
 			"lift_duration"
 			{
-				"value"				"1.2 1.4 1.6 1.8 2 2.2 2.4 2.6 2.8 3.0"
+				"value"				"0.6 0.8 1.0 1.2 1.4 1.6 1.8 2.0 2.6 3.2"
 				"levelkey"			"quaslevel"
 			}
 			"base_damage"			
@@ -480,7 +481,7 @@
 			}
 			"wex_damage"
 			{
-				"value"				"450 900 1350 1800 2250 2700 3150 3600 4050 4500"
+				"value"				"450 900 1350 1800 2250 2700 3150 3600 4950 6300"
 				"CalculateSpellDamageTooltip"	"1"
 				"levelkey"			"wexlevel"
 			}
@@ -535,7 +536,7 @@
 		"AbilityCastRange"				"950"
 		"AbilityCastPoint"				"0.05"
 		"AbilityCastAnimation"			"ACT_INVALID"
-
+		"AbilityCooldown"				"20"
 		"AbilityManaCost"				"125"
 			
 		// Special
@@ -554,7 +555,7 @@
 			}
 			"mana_burned"
 			{
-				"value"			"100 175 250 325 400 475 550 625 700 775"
+				"value"			"100 175 250 325 400 475 550 625 850 1075"
 				"levelkey"				"wexlevel"
 			}
 			"damage_per_mana_pct"					
@@ -612,7 +613,7 @@
 		"AbilityCastRange"				"650"
 		"AbilityCastPoint"				"0.05"
 		"AbilityCastAnimation"			"ACT_INVALID"
-
+		"AbilityCooldown"				"15"
 		"AbilityManaCost"				"100"
 			
 		// Special
@@ -621,13 +622,13 @@
 		{
 			"bonus_attack_speed"
 			{
-				"value"					"10 22 34 46 58 70 82 94 106 118"
+				"value"					"10 22 34 46 58 70 82 94 130 166"
 				"levelkey"				"wexlevel"
 				"special_bonus_unique_invoker_5"	"+30"
 			}
 			"bonus_damage"
 			{
-				"value"					"100 220 340 460 580 700 820 940 1060 1180"
+				"value"					"100 220 340 460 580 700 820 940 1300 1660"
 				"levelkey"				"exortlevel"
 				"special_bonus_unique_invoker_5"	"+30"
 				"CalculateSpellDamageTooltip"	"0"
@@ -676,7 +677,7 @@
 		{
 			"AbilityCooldown"
 			{
-				"value"					"50"
+				"value"					"70"
 			}
 			"land_time"					"1.3"
 			"area_of_effect"			
@@ -690,7 +691,7 @@
 			}
 			"travel_distance"
 			{
-				"value"					"465 615 780 930 1095 1245 1410 1575 1725 1890"
+				"value"					"465 615 780 930 1095 1245 1410 1575 2055 2505"
 				"levelkey"				"wexlevel"
 				"special_bonus_facet_invoker_exort_focus"
 				{
@@ -715,7 +716,7 @@
 			"end_vision_duration"		"3.0"
 			"main_damage"
 			{
-				"value"					"550 800 1050 1300 1550 1800 2050 2200 2350 2500"
+				"value"					"1100 1600 2100 2600 3100 3600 4100 4600 6100 7600"
 				"levelkey"				"exortlevel"
 				"CalculateSpellDamageTooltip"	"1"
 				//"special_bonus_facet_invoker_exort_focus"
@@ -724,10 +725,10 @@
 				//	"special_bonus_shard"		"+75"
 				//}
 			}
-			"burn_duration"				"3.0"
+			"burn_duration"				"9.0"
 			"burn_dps"
 			{
-				"value"					"100 150 200 250 300 350 400 450 500 550"
+				"value"					"300 450 600 750 900 1050 1200 1350 1800 2250"
 				"levelkey"				"exortlevel"
 				"CalculateSpellDamageTooltip"	"1"
 				"DamageTypeTooltip"		"DAMAGE_TYPE_MAGICAL"
@@ -785,12 +786,13 @@
 			}
 			"AbilityCooldown"
 			{
-				"value"				"23"
+				"value"				"18"
 				"special_bonus_unique_invoker_11" "-4"
 			}
 			"damage"
 			{
-				"value"					"2000 2500 3000 3500 4000 4500 5000 5500 6000 6500"
+				"value"										"2000 2500 3000 3500 4000 4500 5000 5500 7000 8500"
+				"special_bonus_facet_invoker_exort_focus"	"=4000 =5000 =6000 =7000 =8000 =9000 =10000 =11000 =14000 =17000"
 				"CalculateSpellDamageTooltip"	"1"
 				"levelkey"				"exortlevel"
 			}
@@ -812,7 +814,7 @@
 			}
 			"cataclysm_cooldown"
 			{
-				"value"					"60"
+				"value"					"0"
 			}
 			"cataclysm_min_range"
 			{
@@ -856,39 +858,40 @@
 		"AbilityManaCost"				"75"
 		"AbilityCastPoint"				"0.05"
 		"AbilityCastAnimation"			"ACT_INVALID"
+		"AbilityCooldown"				"27"
 		
 		// Special
 		"AbilityValues"
 		{
 			"spirit_damage"			
 			{
-				"value"			"200 300 400 500 600 700 800 900 1000 1100"
+				"value"			"200 300 400 500 600 700 800 900 1200 1500"
 				"CalculateAttackDamageTooltip"	"1"
 				"levelkey"		"exortlevel"
 			}
 			"spirit_mana"			
 			{	
-				"value"			"100 150 200 250 300 350 400 450 500 550"
+				"value"			"100 150 200 250 300 350 400 450 600 750"
 				"levelkey"		"exortlevel"
 			}
 			"spirit_armor"
 			{
-				"value"			"0 1 2 3 4 5 6 7 8 9"
+				"value"			"0 1 2 3 4 5 6 7 10 13"
 				"levelkey"		"exortlevel"
 			}
 			"spirit_attack_range"	
 			{
-				"value"			"300 365 430 495 560 625 690 755 820 885"
+				"value"			"300 365 430 495 560 625 690 755 950 1145"
 				"levelkey"		"quaslevel"
 			}
 			"spirit_hp"				
-			{	"value"			"3000 4000 5000 6000 7000 8000 9000 10000 11000 12000"
+			{	"value"			"6000 8000 10000 12000 14000 16000 18000 20000 26000 30000"
 				"CalculateAttributeTooltip"	"1"
 				"levelkey"		"quaslevel"
 			}
 			"spirit_duration"
 			{
-				"value"			"10 20 30 40 50 60 70 80 90 100"
+				"value"			"20 22 24 26 28 30 32 34 40 46"
 				"levelkey"		"quaslevel"
 			}
 			"armor_per_attack"
@@ -899,11 +902,13 @@
 			"extra_spirit_count_quas"	
 			{
 				"value" 				"1 1 1 2 2 2 2 3 3 3"
+				"special_bonus_facet_invoker_exort_focus"	"=2 =2 =3 =3 =4 =4 =5 =6 =6 =6"
 				"levelkey"		"quaslevel"
 			}
 			"extra_spirit_count_exort"
 			{
 				"value" 				"1 1 1 2 2 2 2 3 3 3"
+				"special_bonus_facet_invoker_exort_focus"	"=2 =2 =3 =3 =4 =4 =5 =6 =6 =6"
 				"levelkey"		"exortlevel"
 			}
 		}
@@ -957,6 +962,7 @@
 		"AbilityManaCost"				"125"
 		"AbilityCastPoint"				"0.05"
 		"AbilityCastAnimation"			"ACT_INVALID"
+		"AbilityCooldown"				"20"
 		
 		// Special
 		//-------------------------------------------------------------------------------------------------------------
@@ -964,18 +970,18 @@
 		{
 			"duration"
 			{
-				"value"				"3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0 12.0"
+				"value"				"3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 13.0 16.0"
 				"levelkey"			"quaslevel"
 			}
 			"slow"
 			{
-				"value"				"-20 -40 -60 -80 -100 -120 -140 -160 -180 -200"
+				"value"				"-20 -40 -60 -80 -100 -120 -140 -160 -220 -280"
 				"levelkey"			"quaslevel"
 			}
 			"slow_duration"			"2.0"
 			"damage_per_second"
 			{
-				"value"				"80 160 240 320 400 480 560 640 720 800"
+				"value"				"80 160 240 320 400 480 560 640 880 1120"
 				"CalculateSpellDamageTooltip"	"1"
 				"levelkey"			"exortlevel"
 				"special_bonus_unique_invoker_ice_wall_dps" "+50"
@@ -1084,7 +1090,7 @@
 		"AbilityCastRange"				"1000"
 		"AbilityCastPoint"				"0.05"
 		"AbilityCastAnimation"			"ACT_INVALID"
-
+		"AbilityCooldown"				"25"
 		"AbilityManaCost"				"300"
 		"AbilityModifierSupportValue"	"0.5"	// Applies 2 modifiers
 
@@ -1112,18 +1118,18 @@
 			"end_vision_duration"		"1.75"
 			"damage"
 			{
-				"value"					"700 1100 1500 1900 2300 2700 3100 3500 3900 4300"
+				"value"					"700 1100 1500 1900 2300 2700 3100 3500 4700 5900"
 				"CalculateSpellDamageTooltip"	"1"
 				"levelkey"				"exortlevel"
 			}
 			"knockback_duration"
 			{
-				"value"					"1.1 1.2 1.3 1.4 1.5 1.6 1.7 1.8 1.9 2.0"
+				"value"					"1.1 1.2 1.3 1.4 1.5 1.6 1.7 1.8 2.1 2.4"
 				"levelkey"				"quaslevel"
 			}
 			"disarm_duration"
 			{
-				"value"					"1.5 2.0 2.5 3.0 3.5 4.0 4.5 5.0 5.5 6.0"
+				"value"					"1.5 2.0 2.5 3.0 3.5 4.0 4.5 5.0 6.5 8.0"
 				"levelkey"				"wexlevel"
 			}
 			"radial_count"

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_lone_druid.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_lone_druid.txt
@@ -61,7 +61,7 @@
 		{
 			"bear_hp"
 			{
-				"value"									"1100 1400 1700 2000"	
+				"value"									"8000 13000 18000 23000"		//just tooltip
 			}
 			"bear_regen_tooltip"
 			{
@@ -83,7 +83,7 @@
 			"bear_movespeed"			
 			{
 				"value"									"300 330 360 390"
-				"special_bonus_unique_lone_druid_11"	"+25"
+				"special_bonus_unique_lone_druid_11"	"+50"
 
 			}
 			"bear_magic_resistance"
@@ -219,7 +219,7 @@
 			}
 			"AbilityCooldown"				
 			{
-				"value"				"38 32 26 20"
+				"value"				"29 26 23 20"
 				"special_bonus_unique_lone_druid_4"			"-5"
 			}
 		}

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_pangolier.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_pangolier.txt
@@ -64,7 +64,7 @@
 			}
 			"damage"
 			{
-				"value"								"300 600 900 1200"
+				"value"								"600 1200 1800 2400"
 				"special_bonus_unique_pangolier_3"	"+100%"
 				"CalculateSpellDamageTooltip"		"0"
 				"CalculateAttackDamageTooltip"		"1"
@@ -170,7 +170,7 @@
 				"special_bonus_facet_pangolier_double_jump"					"=50"
 			}
 			"jump_duration"			"0.4"
-			"jump_duration_gyroshell"	"0.75"
+			"jump_duration_gyroshell"	"0.4"
 			"jump_height"			"250"
 			"jump_height_gyroshell"	"350"
 			"jump_horizontal_distance"	"225"
@@ -295,10 +295,14 @@
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilityValues"
 		{
-			"AbilityDamage"					"750 1500 2250"
+			"AbilityDamage"
+			{
+				"value"							"750 1500 2250"
+				"CalculateSpellDamageTooltip"	"1"
+			}
 			"damage_pct"				
 			{
-				"value"							"100"
+				"value"							"100 125 150"
 				"CalculateSpellDamageTooltip"	"0"		
 			}
 			"AbilityCooldown"				
@@ -338,12 +342,12 @@
 			"knockback_radius"		
 			{
 				"value"						"150"
-				"affected_by_aoe_increase"	"1"		
+				"affected_by_aoe_increase"	"0"		
 			}			
 			"duration"				
 			{
 				"value"										"10.0"
-				"special_bonus_unique_pangolier_6"			"+4	"
+				"special_bonus_unique_pangolier_6"			"+4"
 				"special_bonus_facet_pangolier_thunderbolt"	"0"
 			}
 			"jump_recover_time"				"0.25"

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_razor.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_razor.txt
@@ -131,7 +131,7 @@
 
 		// Time		
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityCooldown"				"50 40 30 20"
+		"AbilityCooldown"				"35 30 25 20"
 
 		// Cost
 		//-------------------------------------------------------------------------------------------------------------
@@ -143,13 +143,13 @@
 		{
 			"drain_length"
 			{
-				"value"											"10"
+				"value"											"7"
 				"special_bonus_unique_razor_3"					"+6"				
 			}
 			"drain_duration"									"12 14 16 18"
 			"drain_rate"
 			{
-				"value"											"25 50 75 100"
+				"value"											"55 90 125 160"
 				"special_bonus_unique_razor"					"+50"
 				"CalculateAttackDamageTooltip"					"1"
 			}

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_snapfire.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_snapfire.txt
@@ -27,7 +27,7 @@
 		// Cost
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilityManaCost"									"85 90 95 100"
-		"AbilityCooldown"									"18 15 12 9"
+		"AbilityCooldown"									"15 13 11 9"
 
 		// Special
 		//-------------------------------------------------------------------------------------------------------------
@@ -41,20 +41,20 @@
 			"damage"
 			{
 				"value"										"1000 1600 2200 2800"
-				"special_bonus_unique_snapfire_7"			"+25%"
+				"special_bonus_unique_snapfire_7"			"+50%"
 				"CalculateSpellDamageTooltip"				"1"
 			}
 			"blast_speed"									"3000"
 			"blast_width_initial"		
 			{
-				"value"										"225"
-				"special_bonus_facet_snapfire_full_bore"	"=75"
+				"value"										"325"
+				"special_bonus_facet_snapfire_full_bore"	"=125"
 				"affected_by_aoe_increase"					"1"		
 			}
 			"blast_width_end"
 			{
-				"value"										"400"
-				"special_bonus_facet_snapfire_full_bore"	"=270"
+				"value"										"600"
+				"special_bonus_facet_snapfire_full_bore"	"=320"
 				"affected_by_aoe_increase"					"1"		
 			}
 			"debuff_duration"
@@ -65,7 +65,7 @@
 			"movement_slow_pct"								"100"
 			"attack_slow_pct"								"100"
 			"point_blank_range"								"450"
-			"point_blank_dmg_bonus_pct"						"50.0"
+			"point_blank_dmg_bonus_pct"						"100.0"
 			"movement_slow_pct"								"100"
 			"attack_slow_pct"								"100"
 			"point_blank_range"			
@@ -73,7 +73,7 @@
 				"value" "450"
 				"special_bonus_facet_snapfire_full_bore"	"=650"
 			}
-			"point_blank_dmg_bonus_pct"						"50"
+			"point_blank_dmg_bonus_pct"						"100"
 			"bonus_applies_at_long_range"
 			{
 				"value"										"0"
@@ -138,8 +138,8 @@
 
 		// Time		
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityCooldown"				"120 110 100"
-		"AbilityDuration"				"5.5"
+		"AbilityCooldown"				"60 50 40"
+		"AbilityDuration"				"3"
 
 		// Cost
 		//-------------------------------------------------------------------------------------------------------------
@@ -171,7 +171,7 @@
 				"special_bonus_unique_snapfire_mortimer_kisses_impact_damage"	"+50%" 
 
 			}
-			"duration_tooltip"													"4.5"
+			"duration_tooltip"													"3"
 			"projectile_vision"
 			{
 				"value" "500"
@@ -192,11 +192,11 @@
 			}
 			"burn_ground_duration"												"3.0"
 			"dist_change_speed"													"75"
-			"min_range"															"350"
+			"min_range"															"150"
 			"min_lob_travel_time"												"0.8"
 			"max_lob_travel_time"												"2.0"
 			"delay_after_last_projectile"										"0.5"
-			"burn_linger_duration"												"1.0"
+			"burn_linger_duration"												"3.0"
 		}
 	}
 
@@ -227,14 +227,14 @@
 
 		// Time		
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityCastRange"				"150"
-		"AbilityCooldown"				"40"
+		"AbilityCastRange"				"300"
+		"AbilityCooldown"				"35"
 
 		// Special
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilityValues"
 		{
-			"max_time_in_belly"		"3.0"
+			"max_time_in_belly"		"6.0"
 		}
 		"AbilityCastAnimation"		"ACT_DOTA_CAST_ABILITY_1"
 	}
@@ -350,25 +350,25 @@
 		{
 			"AbilityCooldown"						
 			{ 
-				"value"								"21 19 17 15"
+				"value"								"15 14 13 12"
 				"special_bonus_unique_snapfire_cookie_cooldown"		"-4"
 			}
 			"projectile_speed"						"1000"
 			"pre_hop_duration"						"0.0"
 			"jump_duration"			
 			{
-				"value"								"0.484" //"0.431 0.484 0.538 0.592" // proportional to horizontal distance
-				"special_bonus_shard"				"+0.2"
+				"value"								"0.384" //"0.431 0.484 0.538 0.592" // proportional to horizontal distance
+				"special_bonus_shard"				"+0.0"
 			}
 			"jump_height"			
 			{
-				"value"								"257" //"228 257 285 314" // proportional to horizontal distance
+				"value"								"157" //"228 257 285 314" // proportional to horizontal distance
 				"special_bonus_shard"				"+105"
 			}
 			"jump_horizontal_distance"	
 			{
-				"value"								"425" //"400 450 500 550"
-				"special_bonus_shard"				"+175"
+				"value"								"325" //"400 450 500 550"
+				"special_bonus_shard"				"+75"
 			}
 			"pre_land_anim_time"					"0.14"
 			"landing_gesture_duration"				"0.6"
@@ -390,7 +390,7 @@
 			"self_cast_delay"		"0.3"
 			"target_heal"			
 			{
-				"value"								"400 800 1200 1600"
+				"value"								"800 1600 2400 3200"
 				"special_bonus_unique_snapfire_5"	"+100%"
 				"CalculateSpellHealTooltip"			"1"
 			}
@@ -448,8 +448,8 @@
 
 		// Time
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityCooldown"				"24 20 16 12"
-		"AbilityDuration"				"12"
+		"AbilityCooldown"				"18 16 14 12"
+		"AbilityDuration"				"20"
 
 		// Cost
 		//-------------------------------------------------------------------------------------------------------------
@@ -472,12 +472,12 @@
 			}
 			"damage_pct"
 			{
-				"value"												"30"
+				"value"												"30 40 50 60"
 				"special_bonus_unique_snapfire_6"					"+60"
 			}
 			"attack_speed_bonus"									"300"
 			"attack_range_bonus"									"160 240 320 400"
-			"buff_duration_tooltip"									"12"
+			"buff_duration_tooltip"									"20"
 			"base_attack_time"										"1.0"
 			"armor_reduction_per_attack"							"0.5"
 			"armor_duration"										"5.0"

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_tusk.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_tusk.txt
@@ -18,7 +18,7 @@
 				"value"	"350"
 				"affected_by_aoe_increase"	"1"
 			}
-			"attack_speed_slow"		"20 30 40 50 60"
+			"attack_speed_slow"		"30 40 50 60"
 		}
 	}
 	//=================================================================================================================
@@ -70,7 +70,7 @@
 			"shard_speed"						"1200.0"
 			"shard_duration"					"7"
 			"shard_angle_step"					"40.0"
-			"shard_distance"					"200"
+			"shard_distance"					"260"
 			"turn_rate_slow"					"0"
 			"aghs_shard_move_slow"	
 			{
@@ -138,8 +138,8 @@
 				"value"							"400 650 900 1150"
 				"CalculateSpellDamageTooltip"	"1"
 			}
-			"stun_duration"						"0.6 0.8 1.0 1.2"
-			"stun_duration_bonus"				"0.2"
+			"stun_duration"						"1.6 1.8 2.0 2.2"
+			"stun_duration_bonus"				"0.4"
 			"snowball_windup_radius"	
 			{
 				"value"	"100"
@@ -356,7 +356,7 @@
 
 		// Time		
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityCooldown"				"16 13 10"
+		"AbilityCooldown"				"7 6 5"
 
 		// Cost
 		//-------------------------------------------------------------------------------------------------------------
@@ -368,7 +368,7 @@
 		{
 			"bonus_damage"
 			{
-				"value"							"500 750 1000"
+				"value"							"1000 1500 2000"
 				"CalculateAttackDamageTooltip"	"1"
 			}
 			"crit_multiplier"

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_weaver.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_weaver.txt
@@ -44,7 +44,7 @@
 			"duration"							"16"
 			"destroy_attacks"
 			{
-				"value"							"3"
+				"value"							"4"
 				"LinkedSpecialBonus"			"special_bonus_unique_weaver_4"
 			}
 			"radius"			
@@ -108,12 +108,12 @@
 				"CalculateSpellDamageTooltip"				"1"
 			}
 			"speed"											"200 230 260 290"
-			"radius"										"175 175 175 175"
+			"radius"										"175 200 225 250"
 			"fade_time"										"0.25"
 			"duration"										"4.0 4.0 4.0 4.0"
 			"AbilityCooldown"
 			{
-				"value"										"15 12 9 6"
+				"value"										"12 10 8 6"
 				"special_bonus_unique_weaver_6"				"-50%"
 			}
 			"geminate_attack_mark_duration"
@@ -172,11 +172,11 @@
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilityValues"
 		{
-			"delay"								"0.15"
+			"delay"								"0.07"
 			"extra_attack"
 			{
-				"value" 						"1"
-				"special_bonus_unique_weaver_5" "+1"
+				"value" 						"1 2 3 4"
+				"special_bonus_unique_weaver_5" "+3"
 			}
 			"bonus_damage"
 			{
@@ -186,8 +186,8 @@
 			}
 			"AbilityCooldown"
 			{
-				"value"							"9.0 7.0 5.0 3.0"
-				"special_bonus_shard"			"-2.0"
+				"value"							"4.0"
+				"special_bonus_shard"			"-1.0"
 				"RequiresShard"					"1"
 			}
 			"shard_beetle_search_range"

--- a/game/dota_addons/ebf/scripts/npc/units/npc_summon_units.txt
+++ b/game/dota_addons/ebf/scripts/npc/units/npc_summon_units.txt
@@ -3056,7 +3056,7 @@
 
 		// Status
 		//----------------------------------------------------------------
-		"StatusHealth"				"825"		// Base health.
+		"StatusHealth"				"8000"		// Base health.
 		"StatusHealthRegen"			"15"			// Health regeneration rate.
 		"StatusMana"				"300"		// Base mana.
 		"StatusManaRegen"			"0.5"		// Mana regeneration rate.		 
@@ -3085,7 +3085,7 @@
 
 		// Status
 		//----------------------------------------------------------------
-		"StatusHealth"				"4500"		// Base health.
+		"StatusHealth"				"13000"		// Base health.
 		"StatusHealthRegen"			"25"		// Health regeneration rate.
 		"StatusMana"				"450"		// Base mana.
 		"StatusManaRegen"			"0.75"		// Mana regeneration rate.		 	
@@ -3101,7 +3101,7 @@
 
 		// Status
 		//----------------------------------------------------------------
-		"StatusHealth"				"8500"		// Base health.
+		"StatusHealth"				"18000"		// Base health.
 		"StatusMana"				"600"			// Base mana.
 		"StatusManaRegen"			"1"		// Mana regeneration rate.		 	
 	}	
@@ -3115,7 +3115,7 @@
 
 		// Status
 		//----------------------------------------------------------------
-		"StatusHealth"				"15000"		// Base health.
+		"StatusHealth"				"23000"		// Base health.
 		"StatusMana"				"750"		// Base mana.
 		"StatusManaRegen"			"1.25"		// Mana regeneration rate.		 	
 	}


### PR DESCRIPTION
Invoker
- Increase statbonus from qwe
- Increase bonus atk dmg per instance from exort and scale
- Most abilities cd lowered abit
- All lvl 9 and 10 abilities value has steep increase for facets purpose
- lower tornado lift duration
- Buff Meteor, contact dmg 2x, dps 3x, burn duration 3x. but increase cd to 70s
- increase sunstrike dmg x2 for Agent facets.
- Increase forge spirit count x2 for Agent facet.
- double forge spirit hp, they have 0 mgc resist.(i cant find where forge spirit file located kek)

Lone Druid
- Increase bear base HP

Pangolier
- increase swashbuckle dmg
- increase rolling thunder bonus dmg %

Razor
- lower static link cd for early lvl
- lower static link duration, but increase drain rate. so razor can gain dmg faster

Snapfire
- Scatterblast; lower cd for early lvl, more aoe, more bonus point blank & talent dmg
- Kiss; lower duration, longer linger dps
- Gobble up, more cast range
- Cookie; lower cd, faster and shorter jump, and more heal
- LilShredder; lower cd, longer duration, increase dmg pct.

Tuskar
- Ice Shard, shard now has gap big enough for heroes to pass but too small for big bosses
- increase snowball stun duration
- increase punch bonus dmg, and lower cd by alot

Weaver
- Increase swarm atk to destroy
- increase sukuchi radius, and lower cd
- increase Geminate extra atk, but increase cd.