### PR TITLE
Heroes & Boss

### DIFF
--- a/game/dota_addons/ebf/resource/addon_english.txt
+++ b/game/dota_addons/ebf/resource/addon_english.txt
@@ -732,9 +732,10 @@
 
 		"DOTA_Tooltip_ability_boss_lifestealer_ghoul_frenzy"                                                "Ghoul Frenzy"
 		"DOTA_Tooltip_ability_boss_lifestealer_ghoul_frenzy_attack_speed_bonus"                             "BONUS ATTACK SPEED:"
-		"DOTA_Tooltip_ability_boss_lifestealer_ghoul_frenzy_Description"                                    "Passively causes Lifestealer's attacks to significantly slow enemy movement speed for %duration% seconds. Grants you Attack Speed."
+		"DOTA_Tooltip_ability_boss_lifestealer_ghoul_frenzy_Description"                                    "Passively causes Lifestealer's attacks to significantly slow enemy movement speed for %duration% seconds. Grants you Attack Speed and Movement Speed."
 		"DOTA_Tooltip_ability_boss_lifestealer_ghoul_frenzy_duration"                                       "DURATION:"
 		"DOTA_Tooltip_ability_boss_lifestealer_ghoul_frenzy_movement_slow"                                  "%MOVEMENT SLOW:"
+		"DOTA_Tooltip_ability_boss_lifestealer_ghoul_frenzy_movement_speed_bonus"                          	"%MOVEMENT SPEED BONUS:"
 
 
 		"DOTA_Tooltip_ability_boss_lifestealer_open_wounds"                                                 "Open Wounds"
@@ -2380,6 +2381,7 @@
 		"DOTA_Tooltip_ability_dark_seer_normal_punch_max_damage"                                            "DAMAGE:"
 		"DOTA_Tooltip_ability_dark_seer_normal_punch_max_stun"                                              "STUN DURATION:"
 		"DOTA_Tooltip_ability_dark_seer_normal_punch_ebf_changes"                                      		"Normal Punch always deals maximum damage and stun."
+		"DOTA_Tooltip_ability_dark_seer_surge_speed_boost"                                      			"SPEED BOOST:"
 		
 		// Dawnbreaker
 		"DOTA_Tooltip_ability_dawnbreaker_break_of_dawn_Description"										"Whenever the sun comes out, Dawnbreaker reveals the whole map to allies for 5 seconds and deals %bonus_damage%%% more damage for %damage_duration% seconds."
@@ -4148,6 +4150,7 @@
 		"DOTA_Tooltip_ability_special_bonus_unique_clockwerk_tech_barrier_bonus_barrier"					"+{s:bonus_barrier}% Barrier From Tech Barrier"
 		"DOTA_Tooltip_ability_special_bonus_unique_clockwerk_tech_barrier_bonus_duration"					"+{s:bonus_duration}s Tech Barrier Duration"
 		"DOTA_Tooltip_ability_special_bonus_unique_clockwerk_6"												"{s:bonus_debuff_immunity_duration} Tech Barrier Debuff Immunity"
+		"DOTA_Tooltip_ability_special_bonus_unique_clockwerk_7"												"-{s:bonus_AbilityCooldown}s Rocket Flare Cooldown
 		"DOTA_Tooltip_ability_special_bonus_unique_crystal_maiden_2"                                        "+{s:bonus_nova_damage}% Crystal Nova Damage"
 		"DOTA_Tooltip_ability_special_bonus_unique_crystal_maiden_3"                                        "+{s:bonus_damage}% Freezing Field Damage"
 		"DOTA_Tooltip_ability_special_bonus_unique_dark_willow_4"                                           "+{s:bonus_attack_damage}% Bedlam Damage"
@@ -4159,7 +4162,7 @@
 		"DOTA_Tooltip_ability_special_bonus_unique_dark_seer_7"												"+{s:bonus_tooltip_outgoing}% Wall of Replica Illusion Damage"
 		"DOTA_Tooltip_ability_special_bonus_unique_death_prophet_3"                                         "+{s:bonus_damage}% Spirit Siphon Damage/Heal"
 		"DOTA_Tooltip_ability_special_bonus_unique_death_prophet_crypt_swarm_damage"						"+{s:bonus_damage}% Crypt Swarm Damage"
-		"DOTA_Tooltip_ability_special_bonus_unique_disruptor_9"                                             "+{s:bonus_bonus_damage}% Glimpse Max Damage"
+		"DOTA_Tooltip_ability_special_bonus_unique_disruptor_9"                                             "+{s:bonus_max_damage} Glimpse Min/Max Damage"
 		"DOTA_Tooltip_ability_special_bonus_unique_doom_4"                                                  "+{s:value}% Scorched Earth Damage"
 		"DOTA_Tooltip_ability_special_bonus_unique_doom_5"                                                  "+{s:bonus_damage}% Doom DPS"
 		"DOTA_Tooltip_ability_special_bonus_unique_drow_ranger_2"                                           "+{s:bonus_damage}% Frost Arrow Damage"
@@ -4439,7 +4442,8 @@
 		"DOTA_Tooltip_ability_special_bonus_unique_winter_wyvern_5"                                         "+{s:bonus_heal_additive}% Cold Embrace Base Heal"
 		"DOTA_Tooltip_ability_special_bonus_unique_winter_wyvern_7"											"+{s:bonus_damage}% Splinter Blast Damage"
 		"DOTA_Tooltip_ability_special_bonus_unique_wisp"                                                    "+{s:bonus_hero_damage}% Spirits Damage"
-		"DOTA_Tooltip_ability_special_bonus_unique_wisp_6"                                                  "-{s:value}s Sacrifice Cooldown"
+		"DOTA_Tooltip_ability_special_bonus_unique_wisp_6"                                                  "-{s:bonus_AbilityCooldown}s Sacrifice Cooldown"
+		"DOTA_Tooltip_ability_special_bonus_unique_wisp_2"													"+{s:bonus_tether_heal_amp}% HP/Mana Transfer"
 		"DOTA_Tooltip_ability_special_bonus_unique_witch_doctor_2"                                          "+{s:bonus_heal_pct}% Max Health Voodoo Heal"
 		"DOTA_Tooltip_ability_special_bonus_unique_witch_doctor_2_facet_witch_doctor_voodoo_festeration"	"+{s:bonus_heal_pct}% Max Health Voodoo Heal"
 		"DOTA_Tooltip_ability_special_bonus_unique_witch_doctor_4"                                          "-{s:bonus_mana_per_second}% Voodoo Restoration Mana Per Second"

--- a/game/dota_addons/ebf/scripts/npc/bosses/boss_bears.txt
+++ b/game/dota_addons/ebf/scripts/npc/bosses/boss_bears.txt
@@ -261,7 +261,7 @@
 
 		// Casting
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityCastPoint"				"0.5 0.5 0.5"
+		"AbilityCastPoint"				"0.0"
 		"AbilityCastAnimation"		"ACT_DOTA_CAST_ABILITY_4"
 
 		// Cost

--- a/game/dota_addons/ebf/scripts/npc/bosses/boss_lifestealers.txt
+++ b/game/dota_addons/ebf/scripts/npc/bosses/boss_lifestealers.txt
@@ -30,7 +30,7 @@
 		"AbilityValues"
 		{
 			"movement_speed_bonus"						"12 16 20 24"
-			"duration"									"3.5"
+			"duration"									"3.5 4.5 5.5 6.5"
 			"bonus_armor"								"5 8 11 14"
 			"magic_resist"
 			{
@@ -62,7 +62,7 @@
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilityValues"
 		{
-			"hp_leech_percent"			"2"
+			"hp_leech_percent"			"2 3 4 5"
 			"hp_damage_percent"			"4 6 8 10"
 		}
 		"AbilityCastAnimation"		"ACT_DOTA_CAST_ABILITY_2"
@@ -93,6 +93,7 @@
 			"movement_slow"												"15 20 25 30"
 			"duration"													"1.5"
 			"attack_speed_bonus"										"50 75 100 125"
+			"movement_speed_bonus"										"12 16 20 24"
 		}
 	}
 	"boss_lifestealer_open_wounds"

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_bane.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_bane.txt
@@ -22,7 +22,7 @@
 
 		// Time		
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityCooldown"				"28 21 14 7"
+		"AbilityCooldown"				"13 11 9 7"
 
 
 		// Cost
@@ -91,7 +91,7 @@
 		{
 			"brain_sap_damage"				
 			{
-				"value"									"900 1600 2300 3000 3700 4400 5100"
+				"value"									"900 1600 2300 3000"
 				"special_bonus_unique_bane_2"			"+100%"
 				"CalculateSpellDamageTooltip" 			"1"
 			}
@@ -245,16 +245,16 @@
 			}
 			"AbilityCooldown"				
 			{
-				"value"								"120 110 100"
-				"special_bonus_scepter"				"-45"
+				"value"								"50"
+				"special_bonus_scepter"				"-10"
 			}
 			"illusion_count"
 			{
-				"special_bonus_scepter" "+2"
+				"special_bonus_scepter" "+1"
 			}
 			"scepter_incoming_illusion_damage"
 			{
-				"special_bonus_scepter"	"50"
+				"special_bonus_scepter"	"30"
 			}
 		}
 	}

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_clockwerk.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_clockwerk.txt
@@ -13,7 +13,7 @@
 		"Innate"						"1"
 		"AbilityValues"
 		{
-			"damage_per_armor"			"0.25"
+			"damage_per_armor"			"0.5"
 		}
 	}
 	//=================================================================================================================
@@ -92,8 +92,8 @@
 			"hookshot_radius_bonus_pct"		"50"
 			"hookshot_duration_bonus_pct"	"50"
 			"rocket_flare_interval"			"0.15"
-			"rocket_flare_offset_pct"		"125"
-			"rocket_flare_rockets"			"2"
+			"rocket_flare_offset_pct"		"75"
+			"rocket_flare_rockets"			"3"
 			"rocket_flare_cooldown"			"3"
 			"jetpack_bonus_speed"			"40"
 			"jetpack_turn_rate"				"75"
@@ -120,7 +120,7 @@
 
 		// Time		
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityCooldown"				"18"
+		"AbilityCooldown"				"18 17 16 15"
 
 		// Cost
 		//-------------------------------------------------------------------------------------------------------------
@@ -134,7 +134,11 @@
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilityValues"
 		{
-			"radius"									"275"
+			"radius"
+			{
+				"value"									"275"
+				"affected_by_aoe_increase"				"1"
+			}
 			"duration"									"10.5"
 			"interval"
 			{	
@@ -143,7 +147,7 @@
 			}
 			"damage"
 			{	
-				"value"									"200 450 700 950"
+				"value"									"300 550 800 1050"
 				"special_bonus_unique_clockwerk_3"		"+100%"
 				"CalculateSpellDamageTooltip"			"1"
 			}
@@ -187,7 +191,7 @@
 				"value"															"35"
 				"LinkedSpecialBonus"											"special_bonus_unique_clockwerk_8"
 			}
-			"push_length"														"300"
+			"push_length"														"150"
 			"push_duration"														"1"
 			"barrier"
 			{	
@@ -250,7 +254,7 @@
 			}
 			"AbilityCooldown"				
 			{
-				"value"											"20.0 18.0 16.0 14.0"
+				"value"											"14 13 12 11"
 				"special_bonus_unique_clockwerk_7" 				"-2"
 			}
 			"slow_pct"		"100"
@@ -275,7 +279,7 @@
 
 		"AbilityDraftUltScepterAbility"		"rattletrap_overclocking"
 		"AbilityDraftUltShardAbility"		"rattletrap_jetpack"
-		"MaxLevel"							"6"
+		"MaxLevel"							"3"
 		"LevelsBetweenUpgrades"				"6"
 
 		// Casting
@@ -286,7 +290,7 @@
 		
 		// Time		
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityCooldown"				"60.0 45.0 30.0"
+		"AbilityCooldown"				"30.0 25.0 20.0"
 		
 		// Cost
 		//-------------------------------------------------------------------------------------------------------------
@@ -313,7 +317,7 @@
 				"value"									"0"
 				"special_bonus_facet_rattletrap_hookup"	"75"
 			}
-			"duration"									"2.0"
+			"duration"									"1.0"
 			"speed"										"6000"
 			"damage"
 			{

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_crystal_maiden.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_crystal_maiden.txt
@@ -106,8 +106,16 @@
 				"special_bonus_unique_crystal_maiden_2"		"+125%"
 				"CalculateSpellDamageTooltip"				"1"
 			}
-			"physical_barrier_amount"						{"special_bonus_facet_crystal_maiden_glacial_guard"	"400 700 1000 1300"}
-			"physical_barrier_self_amount"					{"special_bonus_facet_crystal_maiden_glacial_guard"	"800 1400 2000 2600"}
+			"physical_barrier_amount"						
+			{
+				"special_bonus_facet_crystal_maiden_glacial_guard"	"600 900 1200 1500"
+				"CalculateSpellHealTooltip"							"1"
+			}
+			"physical_barrier_self_amount"					
+			{
+				"special_bonus_facet_crystal_maiden_glacial_guard"	"1800 2700 3600 4500"
+				"CalculateSpellHealTooltip"							"1"
+			}
 			"physical_barrier_duration"						{"special_bonus_facet_crystal_maiden_glacial_guard"	"+4.0"}
 		}
 		"AbilityCastAnimation"		"ACT_DOTA_CAST_ABILITY_1"
@@ -158,8 +166,8 @@
 			}
 			"duration"
 			{
-				"value"										"1.5 2 2.5 3"
-				"special_bonus_unique_crystal_maiden_1"		"+1.25"
+				"value"										"1.5 2.5 3.5 4.5"
+				"special_bonus_unique_crystal_maiden_1"		"+2.25"
 			}
 			"creep_multiplier"								"4"
 			"tick_interval"									"0.25"
@@ -182,12 +190,12 @@
 		{
 			"base_mana_regen"					
 			{
-				"value"													"0.8 1.2 1.6 2.0"
+				"value"													"4 6 8 10"
 				"special_bonus_unique_crystal_maiden_4" 				"+2.5"
 			}
 			"proximity_mana_regen_tooltip"					
 			{
-				"value"													"2.4 3.6 4.8 6.0"
+				"value"													"16 24 32 40"
 				"special_bonus_unique_crystal_maiden_4" 				"+7.5"
 			}
 			"proximity_bonus_radius"		
@@ -196,7 +204,7 @@
 				"special_bonus_facet_crystal_maiden_cold_comfort"		"=1200"
 				"affected_by_aoe_increase"	"1"
 			}
-			"proximity_bonus_factor"									"3"
+			"proximity_bonus_factor"									"4"
 			
 			"activatable"												{"special_bonus_facet_crystal_maiden_arcane_overflow"	"+1"}
 			"activation_spell_amp_pct"									{"special_bonus_facet_crystal_maiden_arcane_overflow"	"=35 =55 =75 =95"}
@@ -206,7 +214,7 @@
 				"special_bonus_facet_crystal_maiden_arcane_overflow"	"=1200"
 				"affected_by_aoe_increase"								"1"
 			}
-			"mana_battery_mana_pct"										{"special_bonus_facet_crystal_maiden_arcane_overflow"	"25"}
+			"mana_battery_mana_pct"										{"special_bonus_facet_crystal_maiden_arcane_overflow"	"100"}
 			"activation_duration"										{"special_bonus_facet_crystal_maiden_arcane_overflow"	"+10.0"}
 			"activation_cooldown"										{"special_bonus_facet_crystal_maiden_arcane_overflow"	"+30.0"}
 		}
@@ -247,7 +255,7 @@
 		{
 			"AbilityChannelTime"				"10"
 			"AbilityCastPoint"					"0"
-			"AbilityCooldown"					"100 95 90"
+			"AbilityCooldown"					"80 70 60"
 			"AbilityDuration"					"10.0"
 			"AbilityManaCost"					"200 400 600"
 			"radius"
@@ -291,7 +299,8 @@
 			"shard_self_movement_speed_slow_pct"
 			{
 				"value"						"0"
-				"special_bonus_shard"		"-75"
+				"special_bonus_shard"		"0"
+				"special_bonus_scepter"		"-75 -50 -25"
 				"RequiresShard"				"1"
 			}
 			"can_move"

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_dark_seer.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_dark_seer.txt
@@ -14,7 +14,7 @@
 
 		"AbilityValues"
 		{
-			"int_to_atkspd"				"0.05"
+			"int_to_atkspd"				"0.07"
 		}
 	}
 	//=================================================================================================================
@@ -35,7 +35,7 @@
 				"value"			"900"
 				"affected_by_aoe_increase"	"1"
 			}
-			"movement_speed_pct"	"8"
+			"movement_speed_pct"	"12"
 		}
 	}
 	//=================================================================================================================
@@ -70,7 +70,7 @@
 		"LevelsBetweenUpgrades"			"1"
 		
 		"IsGrantedByScepter"			"1"
-		"LinkedAbility"					"dark_seer_wall_of_replica"
+		//"LinkedAbility"				"dark_seer_wall_of_replica"
 
 		// Time		
 		//-------------------------------------------------------------------------------------------------------------
@@ -117,7 +117,7 @@
 
 		// Time		
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityCooldown"				"60 50 40 30"
+		"AbilityCooldown"				"30 27 24 21"
 		
 		// Cost
 		//-------------------------------------------------------------------------------------------------------------
@@ -130,7 +130,7 @@
 			"radius"
 			{
 				"value"								"325 400 475 550"
-				"special_bonus_unique_dark_seer_2"	"+100"
+				"special_bonus_unique_dark_seer_2"	"+200"
 			}
 			"duration"					"0.6"
 			"damage"
@@ -208,7 +208,7 @@
 			"bonus_health"	
 			{
 				"value"										"0"
-				"special_bonus_unique_dark_seer_6"			"+2500"
+				"special_bonus_unique_dark_seer_6"			"+4000"
 				"CalculateAttributeTooltip"					"1"
 			}	
 		}
@@ -238,7 +238,7 @@
 		
 		// Time		
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityCooldown"				"24 19 14 9"
+		"AbilityCooldown"				"15 13 11 9"
 		
 		// Cost
 		//-------------------------------------------------------------------------------------------------------------
@@ -252,8 +252,8 @@
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilityValues"
 		{
-			"duration"						"3 4 5 6"
-			"speed_boost"					"550"
+			"duration"						"6"
+			"speed_boost"					"550 750 900 1050"
 			"trail_radius"				
 			{
 				"value" 					"0"
@@ -318,15 +318,16 @@
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilityValues"
 		{
-			"duration"						"30.0"
+			"duration"						"6 8 10"
 			"tooltip_outgoing"
 			{
-				"value"								"70 80 90"
+				"value"								"40 60 80"				//Replica act as unkillable unit to tank, cause Boss illu only have base hp and atk, idk how well dmg out gonna be with scaling.
 				"special_bonus_unique_dark_seer_7"	"+20"
+				"CalculateSpellDamageTooltip"		"1"
 			}
 			"tooltip_replica_total_damage_incoming"
 			{
-				"value"								"500"
+				"value"								"0"
 				"CalculateSpellDamageTooltip"		"0"
 				"DamageTypeTooltip"					"DAMAGE_TYPE_NONE"
 			}				
@@ -339,8 +340,8 @@
 			}
 			"AbilityCooldown"
 			{
-				"value"								"100.0"
-				"special_bonus_unique_dark_seer_13" "-40"
+				"value"								"60.0"
+				"special_bonus_unique_dark_seer_13" "-15"
 			}
 			"wall_damage"
 			{

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_disruptor.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_disruptor.txt
@@ -49,7 +49,7 @@
 			}
 			"radius"						
 			{
-				"value" 							"200 250 300 350 400 450 500"
+				"value" 							"200 250 300 350"
 				"special_bonus_unique_disruptor_3"	"+100"
 				"affected_by_aoe_increase"			"1"
 			}
@@ -58,7 +58,7 @@
 				"value"								"12"
 				"special_bonus_shard"				"+4"
 			}
-			"strike_interval"						"2.0 1.8 1.6 1.2 1.0 0.8 0.5"
+			"strike_interval"						"1.0 0.8 0.6 0.4"
 			"strike_damage"	
 			{
 				"value"								"250 550 850 1150"
@@ -124,7 +124,7 @@
 			"cast_range"								"600 1000 1400 1800"
 			"AbilityCooldown"
 			{
-				"value"									"24 22 20 18"
+				"value"									"18 16 14 12"
 				"special_bonus_unique_disruptor_4"		"-4"
 			}
 			"max_distance"					"1400"
@@ -137,7 +137,7 @@
 			}
 			"max_damage"				
 			{
-				"value"											"100 160 220 280"
+				"value"											"500 750 1000 1500"
 				"special_bonus_unique_disruptor_9"				"+280"
 				"CalculateSpellDamageTooltip"					"1"
 			}
@@ -187,7 +187,8 @@
 			"AbilityCooldown"				
 			{
 				"value"	"20 18 16 14"
-				"special_bonus_unique_disruptor_2"				"-3"			
+				"special_bonus_unique_disruptor_2"		"-3"
+				"special_bonus_scepter"					"-3"			
 			}
 			"radius"					
 			{
@@ -196,7 +197,8 @@
 			}
 			"formation_time"			
 			{
-				"value"				"1"					
+				"value"				"1"
+				"special_bonus_scepter"	"=0"				
 			}
 			"duration"					
 			{
@@ -240,15 +242,17 @@
 		{
 			"AbilityChargeRestoreTime"
 			{
-				"value"					"20 18 16 14"
+				"value"					"16 14 12 10"
 				"special_bonus_unique_disruptor_2" "-3"
+				"special_bonus_scepter"				"-3"
 			}
 
 			"radius"					"350"
 
 			"formation_time"			
 			{
-				"value"				"0.4"					
+				"value"				"0.4"
+				"special_bonus_scepter" "=0"					
 			}
 			"duration"
 			{
@@ -288,7 +292,7 @@
 
 		// Time		
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityCooldown"				"60"
+		"AbilityCooldown"				"60 50 40"
 
 		// Cost
 		//-------------------------------------------------------------------------------------------------------------
@@ -306,7 +310,7 @@
 			{
 				"value"								"550"
 				"affected_by_aoe_increase"			"1"
-				"special_bonus_unique_disruptor_8"	"+150"
+				"special_bonus_unique_disruptor_8"	"+250"
 			}
 			"pulses"	
 			{
@@ -321,7 +325,7 @@
 			"duration"	
 			{
 				"value"								"6.0"
-				"special_bonus_unique_disruptor_7" "+2"
+				"special_bonus_unique_disruptor_7" "+3"
 			}
 		}
 	}

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_grimstroke.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_grimstroke.txt
@@ -19,7 +19,7 @@
 		"AbilityValues"
 		{
 			"debuff_duration"			"4.0"
-			"bonus_spell_damage"		"8"
+			"bonus_spell_damage"		"16"
 		}
 	}
 	//=================================================================================================================
@@ -80,7 +80,7 @@
 			"AbilityCastRange"
 			{
 				"value"										"1400"
-				"special_bonus_unique_grimstroke_3"			"+1000"
+				"special_bonus_unique_grimstroke_3"			"+70%"
 			}
 			"projectile_speed"
 			{
@@ -166,7 +166,7 @@
 
 		// Time		
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityCooldown"				"36 30 24 18"
+		"AbilityCooldown"				"18 16 14 12"
 		
 		// Cost
 		//-------------------------------------------------------------------------------------------------------------
@@ -446,7 +446,7 @@
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilityCastAnimation"			"ACT_DOTA_GS_SOUL_CHAIN"
 		"AbilityCastGestureSlot"		"DEFAULT"
-		"AbilityCooldown"				"70 65 60"
+		"AbilityCooldown"				"35 30 25"
 		"AbilityCastRange"				"700 800 900"
 		"AbilityCastPoint"				"0.15"
 		"AbilityManaCost"				"150 200 250"

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_io.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_io.txt
@@ -22,7 +22,7 @@
 
 		// Time		
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityCooldown"				"12"
+		"AbilityCooldown"				"6"
 
 		// Cost
 		//-------------------------------------------------------------------------------------------------------------
@@ -43,13 +43,21 @@
 			}
 			"movespeed"					
 			{
-				"value"							"6 8 10 12"
-				"special_bonus_unique_wisp_3"	"+5"
+				"value"							"12 16 20 24"
+				"special_bonus_unique_wisp_3"	"+12"
 			}
 			"latch_distance"					"700 700 700 700"
 			"latch_speed"						"1000 1000 1000 1000"
-			"tether_heal_amp"					"60"
-			"tether_mana_amp"					"60"
+			"tether_heal_amp"					
+			{
+				"value"							"40 50 60 70"
+				"special_bonus_unique_wisp_2"	"+35"
+			}
+			"tether_mana_amp"					
+			{
+				"value"							"40 50 60 70"
+				"special_bonus_unique_wisp_2"	"+35"
+			}
 			"self_bonus"						"0"
 			"slow"				
 			{
@@ -118,7 +126,11 @@
 			"min_range"					"200"
 			"max_range"					"650"
 			"hero_hit_radius"			"110"
-			"explode_radius"			"360"
+			"explode_radius"
+			{
+				"value"						"360"
+				"affected_by_aoe_increase"	"1"
+			}
 			"hit_radius"				"150 150 150 150"
 			"spirit_movement_rate"		"250 250 250 250"
 			"spirit_duration"			"19.0 19.0 19.0 19.0"
@@ -180,12 +192,12 @@
 			"bonus_spell_amp"		
 			{
 				"value"									"0"
-				"special_bonus_facet_wisp_kritzkrieg"	"8 10 12 14"
+				"special_bonus_facet_wisp_kritzkrieg"	"15 25 35 45"
 			}
 			"bonus_armor"
 			{
 				"value"									"0"
-				"special_bonus_facet_wisp_medigun"		"4 7 10 13"
+				"special_bonus_facet_wisp_medigun"		"8 14 20 26"
 			}
 			"bonus_mres"
 			{
@@ -194,13 +206,13 @@
 			}
 			"hp_regen"			
 			{
-				"value"									"0.5 0.6 0.7 0.8"
-				"special_bonus_unique_wisp_10"			"+0.2"
+				"value"									"1.6 2.0 2.4 2.8"
+				"special_bonus_unique_wisp_10"			"+0.8"
 			}
 			"duration"
 			{
 				"value"									"8"
-				"special_bonus_unique_wisp_overcharge_duration"			"+1.5"
+				"special_bonus_unique_wisp_overcharge_duration"			"+2"
 			}
 			"shard_bonus_slow_resistance"
 			{
@@ -239,11 +251,11 @@
 
 		"AbilityValues"
 		{
-			"invul_duration"					"6"
-			"sacrifice_hp"						"35"
+			"invul_duration"					"6 7 8"
+			"sacrifice_hp"						"30 35 40"
 			"AbilityCooldown"
 			{
-				"value"							"100 90 80"
+				"value"							"80 70 60"
 				"special_bonus_unique_wisp_6"	"-25"
 			}
 		}

--- a/game/dota_addons/ebf/scripts/npc/units/npc_boss_units.txt
+++ b/game/dota_addons/ebf/scripts/npc/units/npc_boss_units.txt
@@ -1456,7 +1456,7 @@
 		// Movement
 		//----------------------------------------------------------------
 		"MovementCapabilities"		"DOTA_UNIT_CAP_MOVE_GROUND"			// Type of locomotion - ground, air
-		"MovementSpeed"				"235"		// Speed
+		"MovementSpeed"				"350"		// Speed
 		"MovementTurnRate"			"0.5"		// Turning rate.
 
 		// Status
@@ -2351,6 +2351,7 @@
 		"Model"						"models/creeps/neutral_creeps/n_creep_golem_b/n_creep_golem_b.vmdl"	// Model.
 		"ModelScale"				"0.8"
 		"Level"						"10"
+		"vscripts"					"ai/ai_boss_basic"
 
 		// Abilities
 		//----------------------------------------------------------------
@@ -2700,7 +2701,7 @@
 		"SoundSet"					"n_creep_Melee"
 		"Level"						"13"
 		"ModelScale" 				"2.0"
-		"vscripts"					"ai/ai_basic"
+		"vscripts"					"ai/ai_boss_basic"
 	
 		// Abilities
 		//----------------------------------------------------------------


### PR DESCRIPTION
Io
- Tether; lower cd, increase +ms, increase hp/mp rate, lvl10 talent +hp/mp rate
- Overcharge; increase +armor, increase +spellamp, increase max hp regen, increase talent +duration
- Sacrifice; lower cd, increase duration

Grimstroke
- increase innate
- Phantom Embrace; lower cd
- Soulbind; lower cd

Disruptor
- Thunder Strike; lower strike interval
- Glimpse; lower cd, increase dmg
- Kinetic Fence; lower cd
- Scepter; lower kinetic fence and field cd and remove form time
- Static Form; lower cd, increase +aoe talent, increase +duration talent

Dark Seer
- increase facets
- Vacuum; lower cd, increase +aoe talent
- Ion Shell; lower cd
- Surge; increase duration, increase speed
- Wall of Replica; since boss replica only have base stat hp/atk, i make it unkillable and add scaling to outgoing dmg(idk how good its gonna be), but lower cd and lower duration

Crystal Maiden
- Glacial Guard; increase barrier and scale
- Frostbite; increase duration
- Arcane Aura; incrase mana regen
- Freezing Field; lower cd, lower -ms

Clockwerk
- increase innate
- Overclocking; increase rocket
- Battery Assasult; lower cd, increase dmg
- Tech Barrier; decrease knockback
- Rocket Flare; lower cd
- Hookshot; lower cd, lower stun duration

Bane
- Enfeeble; lower cd
- Fiends Grip; lower cd, lower -cd talent, lower scepter illu(less lag), lower scepter dmg taken

Boss Lifestealer
- increase ms
- Rage; increase duration
- Feast; increase hp leech
- Ghoul Frenzy; give -ms

Boss Bear
- remove Primal Roar cast time, to fix ai hiccup keep cancelling roar. hopefully

fix mud golem and ogre minion ai