### PR TITLE
Frost Shield, Slow Burn, Mars

### DIFF
--- a/game/dota_addons/ebf/resource/addon_english.txt
+++ b/game/dota_addons/ebf/resource/addon_english.txt
@@ -4321,7 +4321,7 @@
 		"DOTA_Tooltip_ability_special_bonus_unique_marci_lunge_damage"                                      "+{s:bonus_impact_damage}% Rebound Damage"
     	"DOTA_Tooltip_ability_special_bonus_unique_marci_lunge_range"										"+{s:bonus_max_jump_distance}% Rebound Cast/Jump Range"
 		"DOTA_Tooltip_ability_special_bonus_unique_marci_guardian_damage"									"+{s:bonus_bonus_damage}% Sidekick Damage"
-		"DOTA_Tooltip_ability_special_bonus_unique_mars_spear_bonus_damage"                                 "+{s:value}% Spear Of Mars Damage"
+		"DOTA_Tooltip_ability_special_bonus_unique_mars_spear_bonus_damage"                                 "+{s:bonus_damage}% Spear Of Mars Damage"
 		"DOTA_Tooltip_ability_special_bonus_unique_mars_rebuke_on_bulwark"                                  "+{s:bonus_rebuke_chance}% Active Bulwark Frontal God's Rebuke"
 		"DOTA_Tooltip_ability_special_bonus_unique_mars_rebuke_on_bulwark_Description"                      "While Bulwark is active, there is a chance Mars instantly triggers God's Rebuke when a Hero attacks his front."
 		"DOTA_Tooltip_ability_special_bonus_unique_mars_spear_on_attack"                                    "+{s:bonus_spear_chance}% Short Spear of Mars On Attack"

--- a/game/dota_addons/ebf/scripts/npc/bosses/boss_ogres.txt
+++ b/game/dota_addons/ebf/scripts/npc/bosses/boss_ogres.txt
@@ -98,12 +98,12 @@
 			"slow_duration"						"0.5"
 			"damage"
 			{
-				"value"							"65 85 105 125"
+				"value"							"15 20 25 30"
 				"CalculateSpellDamageTooltip"	"1"
 			}
 			"interval"							"1"
 			"radius"							"600"
-			"duration"							"18"
+			"duration"							"12"
 		}
 		"AbilityCastAnimation"		"ACT_DOTA_CAST_ABILITY_2"
 	}

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_lina.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_lina.txt
@@ -56,7 +56,7 @@
 		{
 			"impact_damage_pct"						
 			{
-				"special_bonus_facet_lina_dot"		"0.6"
+				"special_bonus_facet_lina_dot"		"125"
 			}
 			"damage_penalty_tooltip"				"60"		// show as int on tooltip
 
@@ -71,7 +71,7 @@
 
 			"burn_duration"							
 			{
-				"special_bonus_facet_lina_dot"		"3"
+				"special_bonus_facet_lina_dot"		"0"
 			}
 
 		}
@@ -111,7 +111,7 @@
 				"value"								"850 1650 2450 3250"
 				"LinkedSpecialBonus"				"lina_slow_burn"
 				"LinkedSpecialBonusField"			"impact_damage_pct"
-				"LinkedSpecialBonusOperation"		"SPECIAL_BONUS_MULTIPLY"
+				//"LinkedSpecialBonusOperation"		"SPECIAL_BONUS_MULTIPLY"
 				"CalculateSpellDamageTooltip" 		"1"
 			}
 			"dragon_slave_burn_damage_tooltip"
@@ -195,7 +195,7 @@
 				"special_bonus_unique_lina_3"	"+75%"
 				"LinkedSpecialBonus"			"lina_slow_burn"
 				"LinkedSpecialBonusField"		"impact_damage_pct"
-				"LinkedSpecialBonusOperation"	"SPECIAL_BONUS_MULTIPLY"
+				//"LinkedSpecialBonusOperation"	"SPECIAL_BONUS_MULTIPLY"
 				"CalculateSpellDamageTooltip" 		"1"
 			}
 			"light_strike_array_burn_damage_tooltip"
@@ -340,7 +340,7 @@
 				"value"								"5000 7000 9000"
 				"LinkedSpecialBonus"				"lina_slow_burn"
 				"LinkedSpecialBonusField"			"impact_damage_pct"
-				"LinkedSpecialBonusOperation"		"SPECIAL_BONUS_MULTIPLY"
+				//"LinkedSpecialBonusOperation"		"SPECIAL_BONUS_MULTIPLY"
 				"CalculateSpellDamageTooltip" 		"1"
 			}
 			"burn_damage_tooltip"

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_mars.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_mars.txt
@@ -251,7 +251,7 @@
 			"redirect_range"											"1500"
 			"redirect_speed_penatly"
 			{
-				"value"													"18"
+				"value"													"75"
 				"special_bonus_unique_mars_bulwark_speed"				"-10"
 			}
 			"redirect_close_range"										"350"
@@ -263,11 +263,11 @@
             "scepter_movement_slow_duration"							{"special_bonus_scepter"	"1.0"}
             "scepter_bonus_damage"
 			{
-                "special_bonus_scepter"									"750"
+                "special_bonus_scepter"									"0"
 				"CalculateAttackDamageTooltip"							"1"
             }
 			"stationary_attack_delay"									{"special_bonus_scepter"	"0.0"}
-			"knockback_distance"										{"special_bonus_scepter"	"325"}
+			"knockback_distance"										{"special_bonus_scepter"	"225"}
 			"soldier_attack_range"										{"special_bonus_scepter"	"275"}
 			"rebuke_chance"
 			{


### PR DESCRIPTION
Boss Ogre Magi
- lower Frost Shield dps

Lina
- balance OP combust-slowburn loop deleting group. idk how to fix it, so i just make slow burn facet increase spell by 125% flat on impact, no dps afterwards

Mars
- nerf aghs abit since it also perform atk based on mars atk speed too, remove aghs bonus dmg when active, increase active ms slow, and lower knock back abit

update when :)