### PR TITLE
21

### DIFF
--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_dazzle.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_dazzle.txt
@@ -7,7 +7,7 @@
 	{
 		// General
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_INNATE_UI | DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE"
 		"MaxLevel"						"4"
 		"Innate"						"1"
 		"DependentOnAbility"			"dazzle_nothl_projection"
@@ -82,7 +82,7 @@
 		
 		// Time		
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityCooldown"				"24 21 18 15"
+		"AbilityCooldown"				"18 17 16 15"
 
 		// Cost
 		//-------------------------------------------------------------------------------------------------------------
@@ -172,7 +172,7 @@
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilityCastAnimation"			"ACT_DOTA_SHALLOW_GRAVE"
 		"AbilityCastGestureSlot"		"DEFAULT"
-		"AbilityCastRange"				"700 750 800 850 900 950 1000"
+		"AbilityCastRange"				"700 750 800 850"
 		"AbilityCastPoint"				"0.3"
 
 		// Cost

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_drow_ranger.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_drow_ranger.txt
@@ -34,7 +34,7 @@
 	{
 		// General
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_INNATE_UI | DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE"
 		"Innate"						"1"
 		"MaxLevel"						"4"
 		"DependentOnAbility"			"drow_ranger_marksmanship"
@@ -49,7 +49,7 @@
 				"value"			"1200"
 				"affected_by_aoe_increase"	"1"
 			}
-			"trueshot_agi_bonus_base"			"5 15 25 35"
+			"trueshot_agi_bonus_base"			"4 8 12 16"
 			"trueshot_agi_bonus_per_level"		"1"
 			"trueshot_agi_bonus_allies_pct"		"50"
 			"agi_bonus_pct_tooltip"
@@ -169,7 +169,7 @@
 	{
 		// General
 		//-------------------------------------------------------------------------------------------------------------
-		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_DIRECTIONAL"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_DIRECTIONAL | DOTA_ABILITY_BEHAVIOR_CHANNELLED"
 		"AbilityUnitTargetTeam"			"DOTA_UNIT_TARGET_TEAM_ENEMY"
 		"AbilityUnitTargetType"			"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
 		"AbilityUnitDamageType"			"DAMAGE_TYPE_PHYSICAL"	
@@ -180,7 +180,7 @@
 		// Casting
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilityCastPoint"				"0.0"
-		"AbilityChannelTime"			"1.75"
+		"AbilityChannelTime"			"1.75 2.0 2.25 2.5"
 
 		// Cost
 		//-------------------------------------------------------------------------------------------------------------
@@ -192,13 +192,13 @@
 		{
 			"wave_count"
 			{
-				"value"									"3"
-				"special_bonus_unique_drow_ranger_8"	"+1"
+				"value"									"3 4 5 6"
+				"special_bonus_unique_drow_ranger_8"	"+2"
 			}			
-			"arrow_count_per_wave"						"4"
+			"arrow_count_per_wave"						"4 5 6 7"
 			"arrow_damage_pct"
 			{
-				"value"									"100 120 140 160"
+				"value"									"100 115 130 145"
 				"special_bonus_unique_drow_ranger_1"	"+25%"
 				"CalculateSpellDamageTooltip"			 "0"
 			}
@@ -215,7 +215,7 @@
 			"multishot_movespeed"						
 			{
 				"value"										"0"
-				"special_bonus_facet_drow_ranger_sidestep"			"40"
+				"special_bonus_facet_drow_ranger_sidestep"			"20"
 			}
 		}
 		"AbilityCastAnimation"		"ACT_DOTA_CHANNEL_ABILITY_3"

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_medusa.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_medusa.txt
@@ -11,6 +11,8 @@
 		"SpellDispellableType"			"SPELL_DISPELLABLE_NO"		
 		"AbilitySound"					"Hero_Medusa.ManaShield.On"
 
+		"DependentOnAbility"			"medusa_stone_gaze"
+
 		// Casting
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilityCastPoint"							"0.4 0.4 0.4 0.4"
@@ -19,11 +21,11 @@
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilityValues"
 		{
-			"damage_per_mana"						"12"
+			"damage_per_mana"						"5 15 25 35"
 			"damage_per_mana_per_level"				"2.0"
 			"illusion_percentage"					"60"
 
-			"absorption_pct"						"98"
+			"absorption_pct"						"85"
 			"damage_per_mana_total"
 			{
 				"dynamic_value"			"true"
@@ -126,17 +128,17 @@
 		{
 			"damage_modifier"		
 			{
-				"value"		"-50 -40 -30 -20"
+				"value"		"-30"
 				"special_bonus_unique_medusa_2"	"+8"
 			}
 			"damage_modifier_tooltip"		
 			{	
-				"value"			"50 60 70 80"
+				"value"			"70"
 				"special_bonus_unique_medusa_2"	"+8"
 			}		
 			"arrow_count"
 			{
-				"value"						"4"
+				"value"						"1 2 3 4"
 				"special_bonus_scepter"		"+1"
 			}	
 			"process_procs"
@@ -179,7 +181,7 @@
 				"value"									"15 14 13 12"
 				"special_bonus_unique_medusa_5"			"-3"
 			}
-			"AbilityManaCost"							"80 100 120 140"
+			"AbilityManaCost"							"80 60 40 20"
 			"radius"							
 			{
 				"value"									"450"
@@ -197,7 +199,7 @@
 				"special_bonus_unique_medusa_snake_damage"	"+15%"
 				"CalculateSpellDamageTooltip"				"1"
 			}
-			"snake_mana_steal"							"14 15 16 17"
+			"snake_mana_steal"							"14 18 22 26"
 			"snake_scale"								"35"
 			"initial_speed"								"800"
 			"return_speed"								"800"
@@ -207,17 +209,18 @@
 			"max_attacks"					
 			{
 				"value"									"0"
-				"special_bonus_facet_medusa_engorged"	"+3"
+				"special_bonus_facet_medusa_engorged"	"+10"
+				"CalculateAttackDamageTooltip"			"1"
 			}
 			"mana_per_damage"					
 			{
 				"value"									"0"
-				"special_bonus_facet_medusa_engorged"	"+6"
+				"special_bonus_facet_medusa_engorged"	"+1"
 			}
 			"attack_buff_duration"	
 			{
 				"value"									"0"
-				"special_bonus_facet_medusa_engorged"	"+5"
+				"special_bonus_facet_medusa_engorged"	"+20"
 			}
 		}
 		"AbilityCastAnimation"		"ACT_DOTA_CAST_ABILITY_2"
@@ -244,7 +247,7 @@
 		// Cost
 		//-------------------------------------------------------------------------------------------------------------
 		"AbilityManaCost"				"40 60 80 100"
-		"AbilityCooldown"				"30 27 24 21"
+		"AbilityCooldown"				"18 17 16 15"
 
 		// Stats
 		//-------------------------------------------------------------------------------------------------------------
@@ -276,7 +279,7 @@
 				"special_bonus_special_bonus_unique_medusa_gorgons_grasp_volleys"			"1"
 			}
 
-			"duration"							"0.8 1.2 1.6 2.0"
+			"duration"							"1.6 2.0 2.4 2.8"
 			"damage"
 			{
 				"value"							"300 700 1100 1500"
@@ -319,7 +322,7 @@
 			"AbilityCastRange"					"1200"
 			"AbilityCooldown"					
 			{
-				"value"							"90"
+				"value"							"60"
 				"special_bonus_unique_medusa_stone_gaze_cooldown"							"-50%"
 			}
 			"AbilityManaCost"				

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_phantom_assassin.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_phantom_assassin.txt
@@ -165,6 +165,7 @@
 			{
 				"special_bonus_facet_phantom_assassin_femme_fatale"		"200 300 400 500"
 				"special_bonus_unique_phantom_assassin_strike_aspd"		"+200"
+				"CalculateAttackDamageTooltip"							"1"
 			}
 		}
 		"AbilityCastAnimation"		"ACT_DOTA_CAST_ABILITY_2"

--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_phoenix.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_phoenix.txt
@@ -215,12 +215,12 @@
 				"value"								"70 100 130 160"
 				"CalculateSpellHealTooltip"			"1"
 			}
-			"hp_perc_heal"							"2.5 4.0 5.5 7.0"
+			"hp_perc_heal"							"7.0"
 			"radius"								"130"
 			"tick_interval"					"0.2"
 			"forward_move_speed"			"250"
 			"turn_rate_initial"				"250"
-			"turn_rate"						"25"
+			"turn_rate"						"50"
 			"shard_move_slow_pct"
 			{
 				"value"						"0"
@@ -308,7 +308,7 @@
 			"aura_radius"							"1200"
 			"damage_per_sec"
 			{
-				"value"								"600 900 1200"
+				"value"								"1200 1800 2400"
 				"CalculateSpellDamageTooltip"		"1"
 			}
 			"stun_duration"


### PR DESCRIPTION
- Dazzle: lower Poison Touch cd
- Drow Ranger: lower Precicision Aura, lower Sidestep facet ms penalty, increase Multishot waves and arrow per waves but lower arrow dmg
- Medusa: lower Mana Shield %dmg absorb and increase base dmg per mana, change Split Shot lvlup to increase arrow count but 1 lvl dmg penalty, lower Mystic Snake mana and increase mana steal, buff Engorged facet, lower Gorgon Grasp cd and increase duration, lower Stone Gaze cd
- Phantom Assassin: add scaling to Femme facet Phantom Strike counter atk
- Phoenix: increase Sunray heal% and turnrate, increase Supernova dmg